### PR TITLE
New node exclusion

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -94,4 +94,7 @@ PHEKNOWLATOR_BROAD_NODES_DICT = {
     'Metabolism of proteins': 'https://reactome.org/content/detail/R-HSA-392499',
     'tag': 'http://purl.obolibrary.org/obo/SO_0000324',
     'engineered': 'http://purl.obolibrary.org/obo/SO_0000783',
+    'transcript': 'http://purl.obolibrary.org/obo/SO_0000673',
+    'protein binding': 'http://purl.obolibrary.org/obo/GO_0005515',
+    'Homo sapiens protein': 'http://purl.obolibrary.org/obo/PR_000029067',
 }

--- a/constants.py
+++ b/constants.py
@@ -83,3 +83,15 @@ KGCOVID19_SUBSTRINGS = {
 }
 
 ALL_WIKIPATHWAYS = ['WP4532', 'WP4533', 'WP4534', 'WP4535', 'WP4537', 'WP4538', 'WP4539', 'WP4540','WP4541', 'WP4542', 'WP4553', 'WP4562', 'WP4564', 'WP4565', 'WP4760', 'WP4829', 'WP4856', 'WP5283', 'WP5358', 'WP5368', 'WP5372', 'WP5373', 'WP5382', 'WP5385']
+
+PHEKNOWLATOR_BROAD_NODES_DICT = {
+    'protein_coding_gene': 'http://purl.obolibrary.org/obo/SO_0001217',
+    'Gene expression (Transcription)': 'https://reactome.org/content/detail/R-HSA-74160',
+    'Generic Transcription Pathway': 'https://reactome.org/content/detail/R-HSA-212436',
+    'Metabolism': 'https://reactome.org/content/detail/R-HSA-1430728',
+    'Developmental Biology': 'https://reactome.org/content/detail/R-HSA-1266738',
+    'gene': 'http://purl.obolibrary.org/obo/SO_0000704',
+    'Metabolism of proteins': 'https://reactome.org/content/detail/R-HSA-392499',
+    'tag': 'http://purl.obolibrary.org/obo/SO_0000324',
+    'engineered': 'http://purl.obolibrary.org/obo/SO_0000783',
+}

--- a/create_subgraph.py
+++ b/create_subgraph.py
@@ -13,6 +13,8 @@ import glob
 import sys
 import logging.config
 from pythonjsonlogger import jsonlogger
+import networkx as nx
+import igraph
 
 # logging
 log_dir, log, log_config = 'builds/logs', 'cartoomics_log.log', glob.glob('**/logging.ini', recursive=True)
@@ -24,7 +26,7 @@ except FileNotFoundError:
 logger = logging.getLogger(__name__)
 logging.config.fileConfig(log_config[0], disable_existing_loggers=False, defaults={'log_file': log_dir + '/' + log})
 
-def subgraph_shortest_path(input_nodes_df,graph,g_nodes,labels_all,triples_df,weights,search_type):
+def subgraph_shortest_path(input_nodes_df,graph,weights,search_type,kg_type):
 
     input_nodes_df.columns= input_nodes_df.columns.str.lower()
 
@@ -33,7 +35,7 @@ def subgraph_shortest_path(input_nodes_df,graph,g_nodes,labels_all,triples_df,we
     for i in range(len(input_nodes_df)):
         start_node = input_nodes_df.iloc[i].loc['source_label']
         end_node = input_nodes_df.iloc[i].loc['target_label']
-        shortest_path_df = find_shortest_path(start_node,end_node,graph,g_nodes,labels_all,triples_df,weights,search_type)
+        shortest_path_df = find_shortest_path(start_node,end_node,graph,weights,search_type,kg_type,input_nodes_df)
         all_paths.append(shortest_path_df)
 
     df = pd.concat(all_paths)
@@ -43,7 +45,7 @@ def subgraph_shortest_path(input_nodes_df,graph,g_nodes,labels_all,triples_df,we
 
     return df
 
-def subgraph_shortest_path_pattern(input_nodes_df,graph,g_nodes,labels_all,triples_df,weights,search_type,kg_type,manually_chosen_uris):
+def subgraph_shortest_path_pattern(input_nodes_df,graph,weights,search_type,kg_type,manually_chosen_uris):
 
     input_nodes_df.columns = input_nodes_df.columns.str.lower()
 
@@ -52,7 +54,7 @@ def subgraph_shortest_path_pattern(input_nodes_df,graph,g_nodes,labels_all,tripl
     for i in range(len(input_nodes_df)):
         start_node = input_nodes_df.iloc[i].loc['source']
         end_node = input_nodes_df.iloc[i].loc['target']
-        shortest_path_df,manually_chosen_uris = find_shortest_path_pattern(start_node,end_node,graph,g_nodes,labels_all,triples_df,weights,search_type,kg_type,input_nodes_df,manually_chosen_uris)
+        shortest_path_df,manually_chosen_uris = find_shortest_path_pattern(start_node,end_node,graph,weights,search_type,kg_type,input_nodes_df,manually_chosen_uris)
         if len(shortest_path_df) > 0:
             all_paths.append(shortest_path_df)
 
@@ -67,7 +69,7 @@ def subgraph_shortest_path_pattern(input_nodes_df,graph,g_nodes,labels_all,tripl
 
     return df,manually_chosen_uris
 
-# Have user define weights to upweight
+# Have user define weights to upweight -igraph type only
 def user_defined_edge_weights(graph, triples_df,kg_type ):
     if kg_type == 'pkl':
         edges = graph.labels_all[graph.labels_all['entity_type'] == 'RELATIONS'].label.tolist()
@@ -86,7 +88,7 @@ def user_defined_edge_weights(graph, triples_df,kg_type ):
         to_weight = graph.labels_all[graph.labels_all['label'].isin(to_weight)]['entity_uri'].tolist()
 
     if kg_type == 'kg-covid19':
-        edges = set(list(graph.igraph.es['predicate']))
+        edges = set(list(graph.graph_object.es['predicate']))
         print("### Unique Edges in Knowledge Graph ###")
         print('\n'.join(edges))
         still_adding = True
@@ -100,11 +102,11 @@ def user_defined_edge_weights(graph, triples_df,kg_type ):
             else:
                 to_weight.append(user_input)
 
-    edges= graph.igraph.es['predicate']
-    graph.igraph.es['weight'] = [10 if x in to_weight else 1 for x in edges]
+    edges= graph.graph_object.es['predicate']
+    graph.graph_object.es['weight'] = [10 if x in to_weight else 1 for x in edges]
     return(graph)
 
-# Have user define weights to upweight
+# Have user define weights to upweight - igraph type only
 def user_defined_edge_exclusion(graph,kg_type ):
     if kg_type == 'pkl':
         edges = graph.labels_all[graph.labels_all['entity_type'] == 'RELATIONS'].label.tolist()
@@ -123,7 +125,7 @@ def user_defined_edge_exclusion(graph,kg_type ):
         to_drop = graph.labels_all[graph.labels_all['label'].isin(to_drop)]['entity_uri'].tolist()
         
     if kg_type == 'kg-covid19':
-        edges = set(list(graph.igraph.es['predicate']))
+        edges = set(list(graph.graph_object.es['predicate']))
         print("### Unique Edges in Knowledge Graph ###")
         print('\n'.join(edges))
         still_adding = True
@@ -137,7 +139,7 @@ def user_defined_edge_exclusion(graph,kg_type ):
             else:
                 to_drop.append(user_input)
     for edge in to_drop:
-        graph.igraph.delete_edges(graph.igraph.es.select(predicate = edge))
+        graph.graph_object.delete_edges(graph.graph_object.es.select(predicate = edge))
     return(graph)
 
 
@@ -148,26 +150,45 @@ def automatic_defined_edge_exclusion(graph,kg_type):
     if kg_type != 'pkl':
         to_drop = ['biolink:category','biolink:in_taxon']
     for edge in to_drop:
-        graph.igraph.delete_edges(graph.igraph.es.select(predicate = edge))
-    return(graph)
+        # Remove from graph object
+        if isinstance(graph.graph_object, igraph.Graph):
+            graph.graph_object.delete_edges(graph.graph_object.es.select(predicate = edge))
+        if isinstance(graph.graph_object, nx.Graph):
+            edges_to_delete = [(source, target) for source, target, data in graph.graph_object.edges(data=True) if data.get("predicate") == edge]
+            graph.graph_object.remove_edges_from(edges_to_delete)
+        # Remove from df
+        graph.edgelist = graph.edgelist[graph.edgelist["predicate"] != edge]
+
+    return graph
 
 # Nodes to remove
 def automatic_defined_node_exclusion(graph,kg_type):
     if kg_type == 'pkl':
         to_drop = list(PHEKNOWLATOR_BROAD_NODES_DICT.values())
     for uri in to_drop:
-        # Get the indices of vertices with the label 'protein_coding_gene'
-        indices_to_delete = [v.index for v in graph.igraph.vs if v["name"] == uri]
-        # Delete the vertices by their indices
+        # Remove from graph object
+        # Get the indices of vertices with corresponding label
+        if isinstance(graph.graph_object, igraph.Graph):
+            indices_to_delete = [v.index for v in graph.graph_object.vs if v["name"] == uri]
+        if isinstance(graph.graph_object, nx.Graph):
+            indices_to_delete = [node for node, data in graph.graph_object.nodes(data=True) if node == uri]
+        # Remove the vertices by their indices
         try:
-            graph.igraph.delete_vertices(indices_to_delete)
+            if isinstance(graph.graph_object, igraph.Graph):
+                graph.graph_object.delete_vertices(indices_to_delete)
+            if isinstance(graph.graph_object, nx.Graph):
+                graph.graph_object.remove_nodes_from(indices_to_delete)
         except KeyError:
             print('Specified node to be removed does not exist. Update PHEKNOWLATOR_BROAD_NODES_DICT in constants.py.')
             logging.error('Specified node to be removed does not exist. Update PHEKNOWLATOR_BROAD_NODES_DICT in constants.py.')
             sys.exit(1)
-    return(graph)
+        # Remove from dfs
+        graph.labels_all = graph.labels_all[graph.labels_all["entity_uri"] != uri]
+        graph.edgelist = graph.edgelist[(graph.edgelist["subject"] != uri) | (graph.edgelist["object"] != uri)]
+    print(nx.number_of_nodes(graph.graph_object))
+    return graph
  
-def subgraph_prioritized_path_cs(input_nodes_df,graph,g_nodes,labels_all,triples_df,weights,search_type,triples_file,output_dir,input_dir,embedding_dimensions,kg_type,networkx_graph, find_graph_similarity = False,existing_path_nodes = 'none'):
+def subgraph_prioritized_path_cs(input_nodes_df,graph,weights,search_type,triples_file,output_dir,input_dir,embedding_dimensions,kg_type, find_graph_similarity = False,existing_path_nodes = 'none'):
 
 
     input_nodes_df.columns= input_nodes_df.columns.str.lower()
@@ -191,7 +212,7 @@ def subgraph_prioritized_path_cs(input_nodes_df,graph,g_nodes,labels_all,triples
         else:
             pair_path_nodes = 'none'
         node_pair = input_nodes_df.iloc[i]
-        path_nodes,cs_shortest_path_df,all_paths_cs_values,chosen_path_nodes_cs = prioritize_path_cs(input_nodes_df,node_pair,graph,g_nodes,labels_all,triples_df,weights,search_type,triples_file,input_dir,embedding_dimensions,kg_type,networkx_graph,pair_path_nodes)
+        path_nodes,cs_shortest_path_df,all_paths_cs_values,chosen_path_nodes_cs = prioritize_path_cs(input_nodes_df,node_pair,graph,weights,search_type,triples_file,input_dir,embedding_dimensions,kg_type,pair_path_nodes)
         all_paths.append(cs_shortest_path_df)
         df_paths['source_node'] = [start_node]
         df_paths['target_node'] = [end_node]
@@ -214,7 +235,7 @@ def subgraph_prioritized_path_cs(input_nodes_df,graph,g_nodes,labels_all,triples
 
     return df,all_paths_cs_values,all_path_nodes  #all_chosen_path_nodes
 
-def subgraph_prioritized_path_pdp(input_nodes_df,graph,g_nodes,labels_all,triples_df,weights,search_type,pdp_weight,output_dir, kg_type, networkx_graph, existing_path_nodes = 'none'):
+def subgraph_prioritized_path_pdp(input_nodes_df,graph,weights,search_type,pdp_weight,output_dir, kg_type, networkx_graph, existing_path_nodes = 'none'):
 
     input_nodes_df.columns= input_nodes_df.columns.str.lower()
 
@@ -238,7 +259,7 @@ def subgraph_prioritized_path_pdp(input_nodes_df,graph,g_nodes,labels_all,triple
             pair_path_nodes = 'none'
         node_pair = input_nodes_df.iloc[i]
         node_pair = input_nodes_df.iloc[i]
-        path_nodes,pdp_shortest_path_df,paths_pdp,chosen_path_nodes_pdp = prioritize_path_pdp(input_nodes_df,node_pair,graph,g_nodes,labels_all,triples_df,weights,search_type,pdp_weight,kg_type, networkx_graph,pair_path_nodes)
+        path_nodes,pdp_shortest_path_df,paths_pdp,chosen_path_nodes_pdp = prioritize_path_pdp(input_nodes_df,node_pair,graph,weights,search_type,pdp_weight,kg_type,pair_path_nodes)
         all_paths.append(pdp_shortest_path_df)
         df_paths['source_node'] = [start_node]
         df_paths['target_node'] = [end_node]
@@ -276,7 +297,7 @@ def subgraph_prioritized_path_guiding_term(input_nodes_df,term_row,graph,g_nodes
         else:
             pair_path_nodes = 'none'
         node_pair = input_nodes_df.iloc[i]
-        path_nodes,cs_shortest_path_df,all_paths_cs_values,chosen_path_nodes_cs = prioritize_path_cs(input_nodes_df,node_pair,graph,g_nodes,labels_all,triples_df,weights,search_type,triples_file,input_dir,embedding_dimensions,kg_type,networkx_graph,pair_path_nodes,term_row)
+        path_nodes,cs_shortest_path_df,all_paths_cs_values,chosen_path_nodes_cs = prioritize_path_cs(input_nodes_df,node_pair,graph,weights,search_type,triples_file,input_dir,embedding_dimensions,kg_type,networkx_graph,pair_path_nodes,term_row)
         all_paths.append(cs_shortest_path_df)
         df_paths['source_node'] = [start_node]
         df_paths['target_node'] = [end_node]

--- a/creating_metapaths_from_KG.py
+++ b/creating_metapaths_from_KG.py
@@ -1,6 +1,6 @@
 from inputs import *
 from create_graph import create_graph
-from create_subgraph import automatic_defined_edge_exclusion
+from create_subgraph import automatic_defined_edge_exclusion, automatic_defined_node_exclusion
 from graph_experiments import *
 import ast
 from collections import defaultdict
@@ -38,6 +38,7 @@ def main():
         g = create_graph(triples_list_file,labels_file, kg_type)
         if weights == True:
             g = automatic_defined_edge_exclusion(g,kg_type)
+            g = automatic_defined_node_exclusion(g,kg_type)
 
         manually_chosen_uris = {}
 
@@ -77,7 +78,7 @@ def main():
                     all_pairs['source'] = node_type1[m] 
                     all_pairs['target'] = node_type2[d] 
                     input_df = pd.DataFrame.from_dict([all_pairs])
-                    manually_chosen_uris,pattern = one_path_search_patterns(input_df,g.igraph,g.igraph_nodes,g.labels_all,g.edgelist,search_type,kg_type,manually_chosen_uris)
+                    manually_chosen_uris,pattern = one_path_search_patterns(input_df,g,search_type,kg_type,manually_chosen_uris)
 
                     patterns_all.append(pattern)
     

--- a/creating_subgraph_from_KG.py
+++ b/creating_subgraph_from_KG.py
@@ -1,6 +1,5 @@
 from inputs import *
 from create_graph import create_graph
-from create_graph import kg_to_undirected_networkx
 from assign_nodes import interactive_search_wrapper, skip_self_loops
 from create_subgraph import automatic_defined_node_exclusion, subgraph_prioritized_path_cs
 from create_subgraph import subgraph_prioritized_path_pdp
@@ -10,7 +9,6 @@ from visualize_subgraph import output_visualization
 from evaluation import *
 from tqdm import tqdm
 from memory_management import *
-import networkx
 
 def main():
 
@@ -46,13 +44,13 @@ def main():
         g = automatic_defined_edge_exclusion(g,kg_type)
         g = automatic_defined_node_exclusion(g,kg_type)
 
-    networkx_g = kg_to_undirected_networkx(g)
+    #networkx_g = kg_to_undirected_networkx(g,g.edgelist,g.labels_all)
     
     if cosine_similarity == 'true':
         print("Finding subgraph using user input and KG embeddings for Cosine Similarity......")
 
         #Returns list of all shortest paths for subgraph as all_path_nodes
-        subgraph_cs,all_paths_cs_values,all_path_nodes = subgraph_prioritized_path_cs(s,g.igraph,g.igraph_nodes,g.labels_all,g.edgelist,weights,search_type,triples_list_file,output_dir,input_dir,embedding_dimensions,kg_type,networkx_g)
+        subgraph_cs,all_paths_cs_values,all_path_nodes = subgraph_prioritized_path_cs(s,g,weights,search_type,triples_list_file,output_dir,input_dir,embedding_dimensions,kg_type)
 
 
         print("Outputting CS visualization......")
@@ -66,13 +64,11 @@ def main():
         #Don't need to find shortest paths again if already run for cosine similarity
         if cosine_similarity == 'true':
 
-            print('pdp and cosine true')
-
-            subgraph_pdp,path_pdp,all_path_nodes = subgraph_prioritized_path_pdp(s,g.igraph,g.igraph_nodes,g.labels_all,g.edgelist,weights,search_type,pdp_weight,output_dir,kg_type,networkx_g,all_path_nodes)
+            subgraph_pdp,path_pdp,all_path_nodes = subgraph_prioritized_path_pdp(s,g,weights,search_type,pdp_weight,output_dir,kg_type,all_path_nodes)
     
         else:
 
-            subgraph_pdp,path_pdp,all_path_nodes = subgraph_prioritized_path_pdp(s,g.igraph,g.igraph_nodes,g.labels_all,g.edgelist,weights,search_type,pdp_weight,output_dir,kg_type,networkx_g)
+            subgraph_pdp,path_pdp,all_path_nodes = subgraph_prioritized_path_pdp(s,g,weights,search_type,pdp_weight,output_dir,kg_type)
 
         print("Outputting PDP visualization......")
 
@@ -87,11 +83,11 @@ def main():
             #Don't need to find shortest paths again if already run for cosine similarity
             if cosine_similarity == 'true' or pdp == 'true':
 
-                subgraph_guiding_term,all_paths_cs_values,output_foldername = subgraph_prioritized_path_guiding_term(s,term_row,g.igraph,g.igraph_nodes,g.labels_all,g.edgelist,weights,search_type,triples_list_file,output_dir,input_dir,embedding_dimensions,kg_type,networkx_g,all_path_nodes)
+                subgraph_guiding_term,all_paths_cs_values,output_foldername = subgraph_prioritized_path_guiding_term(s,term_row,g.graph_object,g.graph_nodes,g.labels_all,g.edgelist,weights,search_type,triples_list_file,output_dir,input_dir,embedding_dimensions,kg_type,all_path_nodes)
 
             else:
 
-                subgraph_guiding_term,all_paths_cs_values,output_foldername = subgraph_prioritized_path_guiding_term(s,term_row,g.igraph,g.igraph_nodes,g.labels_all,g.edgelist,weights,search_type,triples_list_file,output_dir,input_dir,embedding_dimensions,kg_type,networkx_g)
+                subgraph_guiding_term,all_paths_cs_values,output_foldername = subgraph_prioritized_path_guiding_term(s,term_row,g.graph_object,g.graph_nodes,g.labels_all,g.edgelist,weights,search_type,triples_list_file,output_dir,input_dir,embedding_dimensions,kg_type)
 
 
             print("Outputting Guiding Term(s) visualization......")

--- a/creating_subgraph_from_KG.py
+++ b/creating_subgraph_from_KG.py
@@ -2,7 +2,7 @@ from inputs import *
 from create_graph import create_graph
 from create_graph import kg_to_undirected_networkx
 from assign_nodes import interactive_search_wrapper, skip_self_loops
-from create_subgraph import subgraph_prioritized_path_cs
+from create_subgraph import automatic_defined_node_exclusion, subgraph_prioritized_path_cs
 from create_subgraph import subgraph_prioritized_path_pdp
 from create_subgraph import  subgraph_prioritized_path_guiding_term
 from create_subgraph import user_defined_edge_exclusion,automatic_defined_edge_exclusion
@@ -44,6 +44,7 @@ def main():
     if weights == True:
         #g = user_defined_edge_exclusion(g,kg_type)
         g = automatic_defined_edge_exclusion(g,kg_type)
+        g = automatic_defined_node_exclusion(g,kg_type)
 
     networkx_g = kg_to_undirected_networkx(g)
     

--- a/find_path.py
+++ b/find_path.py
@@ -1,3 +1,4 @@
+import re
 from graph_embeddings import Embeddings
 import numpy as np
 import pandas as pd
@@ -5,7 +6,8 @@ from scipy import spatial
 from scipy.spatial import distance
 from collections import defaultdict
 from assign_nodes import unique_nodes
-import networkx
+import igraph
+import networkx as nx
 from functools import reduce
 from operator import itemgetter
 
@@ -37,33 +39,43 @@ def get_key(dictionary,value):
         if val == value:
             return key
 
-def define_path_triples(g_nodes,triples_df,path_nodes,search_type):
+def process_path_nodes_value(graph,value):
+
+    if isinstance(graph.graph_object,igraph.Graph):
+        n = graph.graph_nodes[value]
+    if isinstance(graph.graph_object, nx.Graph):
+        n = value
+
+    return n
+
+
+def define_path_triples(graph,path_nodes,search_type):
 
     #Dict to store all dataframes of shortest mechanisms for this node pair
     mechanism_dfs = {}
 
     #Keep track of # of mechanisms generated for this node pair in file name for all shortest paths
     count = 1 
-
     #When there is no connection in graph, path_nodes will equal 1 ([[]]) or when there's a self loop
     if len(path_nodes[0]) != 0:
         for p in range(len(path_nodes)):
             #Dataframe to append each triple to
             full_df = pd.DataFrame()
-            n1 = g_nodes[path_nodes[p][0]]
+            # path_nodes contains integers for igraph, uris for networkx
+            n1 = process_path_nodes_value(graph,path_nodes[p][0])
             for i in range(1,len(path_nodes[p])):
-                n2 = g_nodes[path_nodes[p][i]]
+                n2 = process_path_nodes_value(graph,path_nodes[p][i])
                 if search_type.lower() == 'all':
                     #Try first direction which is n1 --> n2
-                    df = triples_df.loc[(triples_df['subject'] == n1) & (triples_df['object'] == n2)]
+                    df = graph.edgelist.loc[(graph.edgelist['subject'] == n1) & (graph.edgelist['object'] == n2)]
                     full_df = pd.concat([full_df,df])
                     if len(df) == 0:
                         #If no results, try second direction which is n2 --> n1
-                        df = triples_df.loc[(triples_df['object'] == n1) & (triples_df['subject'] == n2)]
+                        df = graph.edgelist.loc[(graph.edgelist['object'] == n1) & (graph.edgelist['subject'] == n2)]
                         full_df = pd.concat([full_df,df])
                 elif search_type.lower() == 'out':
                     #Only try direction n1 --> n2
-                    df = triples_df.loc[(triples_df['subject'] == n1) & (triples_df['object'] == n2)]
+                    df = graph.edgelist.loc[(graph.edgelist['subject'] == n1) & (graph.edgelist['object'] == n2)]
                     full_df = pd.concat([full_df,df])
                 full_df = full_df.reset_index(drop=True)
                 n1 = n2
@@ -85,90 +97,46 @@ def define_path_triples(g_nodes,triples_df,path_nodes,search_type):
     if len(path_nodes) > 1:
         return mechanism_dfs
 
-def find_all_shortest_paths(node_pair,graph,g_nodes,labels_all,triples_df,weights,search_type, kg_type):
+### networkx implementation of find all shortest paths. Still uses both graphs (3/21/24)(LG)
 
+def find_all_shortest_paths(node_pair,graph,weights,search_type, kg_type):
+
+    w = None
     try:
         if node_pair['source_id'] != 'not_needed':
             node1 = node_pair['source_id']
         else:
-            node1 = get_uri(labels_all,node_pair['source_label'], kg_type)
+            node1 = get_uri(graph.labels_all,node_pair['source_label'], kg_type)
     #Handle case where no ID was input for any nodes or only 1 node
     except KeyError: 
-        node1 = get_uri(labels_all,node_pair['source_label'], kg_type)
+        node1 = get_uri(graph.labels_all,node_pair['source_label'], kg_type)
    
     try:
         if node_pair['target_id'] != 'not_needed':
             node2 = node_pair['target_id']
         else:
-            node2 = get_uri(labels_all,node_pair['target_label'], kg_type)
+            node2 = get_uri(graph.labels_all,node_pair['target_label'], kg_type)
     #Handle case where no ID was input for any nodes or only 1 node
     except KeyError:
-        node2 = get_uri(labels_all,node_pair['target_label'], kg_type)
+        node2 = get_uri(graph.labels_all,node_pair['target_label'], kg_type)
     
-    #Add weights if specified
-    if weights:
-        w = graph.es["weight"]
-    else:
-        w = None
+    #Add weights if specified # only igraph supported
+    # if weights:
+    #     w = graph.es["weight"]
 
     #Dict to store all dataframes of shortest mechanisms for this node pair
     mechanism_dfs = {}
 
-    #list of nodes
-    path_nodes = graph.get_all_shortest_paths(v=node1, to=node2, weights=w, mode=search_type)
-    
+    if isinstance(graph.graph_object, nx.Graph):
+        path_nodes = nx.all_shortest_paths(graph.graph_object,node1,node2)
+
+    if isinstance(graph.graph_object, igraph.Graph):
+        path_nodes = graph.get_all_shortest_paths(v=node1, to=node2, weights=w, mode=search_type)
+
     #Remove duplicates for bidirectional nodes, only matters when search type=all for mode
     path_nodes = list(set(tuple(x) for x in path_nodes))
     path_nodes = [list(tup) for tup in path_nodes]
     path_nodes = sorted(path_nodes,key = itemgetter(1))
-
-    #Dictionary of all triples that are shortest paths, not currently used
-    #mechanism_dfs = define_path_triples(g_nodes,triples_df,path_nodes,search_type)
-    
-    return path_nodes
-
-
-### networkx implementation of find all shortest paths. Still uses both graphs (3/21/24)(LG)
-
-def find_all_shortest_paths_networkx(node_pair,graph,g_nodes,labels_all,triples_df,weights,search_type, kg_type, networkx_graph):
-
-    try:
-        if node_pair['source_id'] != 'not_needed':
-            node1 = node_pair['source_id']
-        else:
-            node1 = get_uri(labels_all,node_pair['source_label'], kg_type)
-    #Handle case where no ID was input for any nodes or only 1 node
-    except KeyError: 
-        node1 = get_uri(labels_all,node_pair['source_label'], kg_type)
-   
-    try:
-        if node_pair['target_id'] != 'not_needed':
-            node2 = node_pair['target_id']
-        else:
-            node2 = get_uri(labels_all,node_pair['target_label'], kg_type)
-    #Handle case where no ID was input for any nodes or only 1 node
-    except KeyError:
-        node2 = get_uri(labels_all,node_pair['target_label'], kg_type)
-    
-    #Add weights if specified
-    # if weights:
-    #     w = graph.es["weight"]
-    # else:
-    #     w = None
-
-    #Dict to store all dataframes of shortest mechanisms for this node pair
-    mechanism_dfs = {}
-
-    #list of nodes
-    
-    node1_nx = graph.vs.find(name = node1).index
-    node2_nx = graph.vs.find(name = node2).index
-
-    path_nodes = networkx.all_shortest_paths(networkx_graph,node1_nx,node2_nx)
-
-    #Remove duplicates for bidirectional nodes, only matters when search type=all for mode
-    path_nodes = list(set(tuple(x) for x in path_nodes))
-    path_nodes = [list(tup) for tup in path_nodes]
 
     #Dictionary of all triples that are shortest paths, not currently used
     #mechanism_dfs = define_path_triples(g_nodes,triples_df,path_nodes,search_type)
@@ -189,18 +157,18 @@ def get_embedding(emb,node):
 
     return embedding_array
 
-def calc_cosine_sim(emb,entity_map,path_nodes,g_nodes,triples_df,search_type,labels_all,kg_type,guiding_term,input_nodes_df):
+def calc_cosine_sim(emb,entity_map,path_nodes,graph,search_type,kg_type,guiding_term,input_nodes_df):
 
     #Set target embedding value to target node if no guiding term is provided
     if guiding_term.empty:
-        n1 = g_nodes[path_nodes[0][len(path_nodes[0])-1]]  
+        n1 = process_path_nodes_value(graph,path_nodes[0][len(path_nodes[0])-1]) 
 
     #Set target embedding value to guiding term if it exists
     else:
         try:
             n1 = guiding_term['term_id']
         except KeyError:
-            n1 = get_uri(labels_all,guiding_term['term_label'], kg_type)
+            n1 = get_uri(graph.labels_all,guiding_term['term_label'], kg_type)
 
     n1_int = convert_path_nodes(n1,entity_map)
     target_emb = get_embedding(emb,n1_int)
@@ -214,7 +182,7 @@ def calc_cosine_sim(emb,entity_map,path_nodes,g_nodes,triples_df,search_type,lab
     for l in path_nodes:
         cs = []
         for i in range(0,len(l)-1):
-            n1 = g_nodes[l[i]]
+            n1 = process_path_nodes_value(graph,l[i])
             n1_int = convert_path_nodes(n1,entity_map)
             if n1_int not in list(embeddings.keys()):
                 e = get_embedding(emb,n1_int)
@@ -229,9 +197,9 @@ def calc_cosine_sim(emb,entity_map,path_nodes,g_nodes,triples_df,search_type,lab
     chosen_path_nodes_cs = select_max_path(value_list,path_nodes)
 
     #Will only return 1 dataframe
-    df = define_path_triples(g_nodes,triples_df,chosen_path_nodes_cs,search_type)
+    df = define_path_triples(graph,chosen_path_nodes_cs,search_type)
 
-    df = convert_to_labels(df,labels_all,kg_type,input_nodes_df)
+    df = convert_to_labels(df,graph.labels_all,kg_type,input_nodes_df)
 
     return df,all_paths_cs_values,chosen_path_nodes_cs[0]
 
@@ -318,7 +286,7 @@ def calc_cosine_sim_from_uri_list(emb,entity_map,node_uris,labels_all,kg_type,em
 
     return avg_cosine_sim,embeddings
 
-def calc_pdp(path_nodes,graph,w,g_nodes,triples_df,search_type,labels_all,kg_type,input_nodes_df):
+def calc_pdp(path_nodes,graph,w,search_type,kg_type,input_nodes_df):
 
     #List of pdp for each path in path_nodes, should be same length as path_nodes
     #paths_pdp = []
@@ -329,7 +297,12 @@ def calc_pdp(path_nodes,graph,w,g_nodes,triples_df,search_type,labels_all,kg_typ
     for l in path_nodes:
         pdp = 1
         for i in range(0,len(l)-1):
-            dp = graph.degree(l[i],mode='all',loops=True)
+            if isinstance(graph.graph_object, igraph.Graph):
+                dp = graph.graph_object.degree(l[i],mode='all',loops=True)
+            if isinstance(graph.graph_object, nx.Graph):
+                # Get node name first which is uri
+                node = l[i]
+                dp = graph.graph_object.degree(node)
             dp_damped = pow(dp,-w)
             pdp = pdp*dp_damped
 
@@ -339,9 +312,9 @@ def calc_pdp(path_nodes,graph,w,g_nodes,triples_df,search_type,labels_all,kg_typ
     chosen_path_nodes_pdp = select_max_path(all_paths_pdp_values,path_nodes)
 
     #Will only return 1 dataframe
-    df = define_path_triples(g_nodes,triples_df,chosen_path_nodes_pdp,search_type)
+    df = define_path_triples(graph,chosen_path_nodes_pdp,search_type)
 
-    df = convert_to_labels(df,labels_all,kg_type,input_nodes_df)
+    df = convert_to_labels(df,graph.labels_all,kg_type,input_nodes_df)
 
     return df,all_paths_pdp_values,chosen_path_nodes_pdp
 
@@ -401,10 +374,10 @@ def convert_to_labels(df,labels_all,kg_type,input_nodes_df):
 
 # Wrapper functions
 #Returns the path as a dataframe of S/P/O of all triples' labels within the path
-def find_shortest_path(start_node,end_node,graph,g_nodes,labels_all,triples_df,weights,search_type, kg_type):
+def find_shortest_path(start_node,end_node,graph,weights,search_type, kg_type, input_nodes_df):
 
-    node1 = get_uri(labels_all,start_node,kg_type)
-    node2 = get_uri(labels_all,end_node,kg_type)
+    node1 = get_uri(graph.labels_all,start_node,kg_type)
+    node2 = get_uri(graph.labels_all,end_node,kg_type)
 
     #Add weights if specified
     if weights:
@@ -415,14 +388,14 @@ def find_shortest_path(start_node,end_node,graph,g_nodes,labels_all,triples_df,w
     #list of nodes
     path_nodes = graph.get_shortest_paths(v=node1, to=node2, weights=w, mode=search_type)
 
-    df = define_path_triples(g_nodes,triples_df,path_nodes,search_type)
+    df = define_path_triples(graph,path_nodes,search_type)
 
-    df = convert_to_labels(df,labels_all,kg_type,input_nodes_df)
+    df = convert_to_labels(df,graph,kg_type,input_nodes_df)
 
     return df
 
 #Returns the path as a dataframe of S/P/O of all triples' labels within the path
-def find_shortest_path_pattern(start_node,end_node,graph,g_nodes,labels_all,triples_df,weights,search_type, kg_type,s,manually_chosen_uris):
+def find_shortest_path_pattern(start_node,end_node,graph,weights,search_type, kg_type,s,manually_chosen_uris):
 
     node1 = start_node
     node2 = end_node
@@ -438,24 +411,21 @@ def find_shortest_path_pattern(start_node,end_node,graph,g_nodes,labels_all,trip
 
     if len(path_nodes[0]) > 0:
 
-        df = define_path_triples(g_nodes,triples_df,path_nodes,search_type)
+        df = define_path_triples(graph,path_nodes,search_type)
 
     else:
         df = pd.DataFrame()
 
     return df,manually_chosen_uris
 
-def prioritize_path_cs(input_nodes_df,node_pair,graph,g_nodes,labels_all,triples_df,weights,search_type,triples_file,input_dir,embedding_dimensions, kg_type, networkx_graph, path_nodes = 'none', guiding_term=pd.Series()):
-  
-    # igraph implementation
-    # path_nodes = find_all_shortest_paths(node_pair,graph,g_nodes,labels_all,triples_df,False,search_type, kg_type)
+def prioritize_path_cs(input_nodes_df,node_pair,graph,weights,search_type,triples_file,input_dir,embedding_dimensions, kg_type, path_nodes = 'none', guiding_term=pd.Series()):
   
     if path_nodes == 'none':
-        path_nodes = find_all_shortest_paths_networkx(node_pair,graph,g_nodes,labels_all,triples_df,False,'all', kg_type, networkx_graph)
+        path_nodes = find_all_shortest_paths(node_pair,graph,False,'all', kg_type)
 
     e = Embeddings(triples_file,input_dir,embedding_dimensions, kg_type)
     emb,entity_map = e.generate_graph_embeddings(kg_type)
-    df,all_paths_cs_values,chosen_path_nodes_cs = calc_cosine_sim(emb,entity_map,path_nodes,g_nodes,triples_df,search_type,labels_all, kg_type, guiding_term,input_nodes_df)
+    df,all_paths_cs_values,chosen_path_nodes_cs = calc_cosine_sim(emb,entity_map,path_nodes,graph,search_type, kg_type, guiding_term,input_nodes_df)
 
     return path_nodes,df,all_paths_cs_values,chosen_path_nodes_cs
 
@@ -475,29 +445,29 @@ def generate_comparison_terms_dict(subgraph_cosine_sim,term_row,avg_cosine_sim,a
     return subgraph_cosine_sim
 
 
-def prioritize_path_pdp(input_nodes_df,node_pair,graph,g_nodes,labels_all,triples_df,weights,search_type,pdp_weight, kg_type, networkx_graph, path_nodes = 'none'):
+def prioritize_path_pdp(input_nodes_df,node_pair,graph,weights,search_type,pdp_weight, kg_type, path_nodes = 'none'):
 
     if path_nodes == 'none':
-        path_nodes = find_all_shortest_paths_networkx(node_pair,graph,g_nodes,labels_all,triples_df,False,search_type, kg_type,networkx_graph)
+        path_nodes = find_all_shortest_paths(node_pair,graph,False,search_type, kg_type)
     
 
-    df,all_paths_pdp_values,chosen_path_nodes_pdp = calc_pdp(path_nodes,graph,pdp_weight,g_nodes,triples_df,search_type,labels_all, kg_type,input_nodes_df)
+    df,all_paths_pdp_values,chosen_path_nodes_pdp = calc_pdp(path_nodes,graph,pdp_weight,search_type, kg_type,input_nodes_df)
 
     return path_nodes,df,all_paths_pdp_values,chosen_path_nodes_pdp[0]
 
-# expand nodes by drugs 1 hop away
+# expand nodes by drugs 1 hop away # only for igraph object
 def drugNeighbors(graph,nodes, kg_type,input_nodes_df):
     neighbors = []
     if kg_type == 'kg-covid19':
         nodes = list(graph.labels_all[graph.labels_all['label'].isin(nodes)]['id'])
     for node in nodes:
-        tmp_nodes = graph.igraph.neighbors(node,mode = "in")
-        tmp = graph.igraph.vs(tmp_nodes)['name']
+        tmp_nodes = graph.graph_object.neighbors(node,mode = "in")
+        tmp = graph.graph_object.vs(tmp_nodes)['name']
         drug_neighbors = [i for i in tmp if re.search(r'Drug|Pharm',i)]
         if len(drug_neighbors) != 0:
             for source in drug_neighbors:
-                path = graph.igraph.get_shortest_paths(v = source, to = node)
-                path_triples = define_path_triples(graph.igraph_nodes,graph.edgelist,path, 'all')
+                path = graph.graph_object.get_shortest_paths(v = source, to = node)
+                path_triples = define_path_triples(graph.graph_nodes,graph.edgelist,path, 'all')
                 path_labels = convert_to_labels(path_triples,graph.labels_all,kg_type,input_nodes_df)
                 neighbors.append(path_labels)
     all_neighbors = pd.concat(neighbors)

--- a/graph.py
+++ b/graph.py
@@ -1,8 +1,8 @@
 
 class KnowledgeGraph:
 
-    def __init__(self, edgelist, labels_all, igraph, igraph_nodes):
+    def __init__(self, edgelist, labels_all, graph, graph_nodes):
         self.edgelist = edgelist
         self.labels_all = labels_all
-        self.igraph = igraph
-        self.igraph_nodes = igraph_nodes
+        self.graph_object = graph
+        self.graph_nodes = graph_nodes

--- a/graph_experiments.py
+++ b/graph_experiments.py
@@ -54,15 +54,15 @@ def get_nodes_from_input(input_df,s):
 
 
 #input_df is the selected nodes we want to search, s is the original mapped file with all source/target/source_label
-def one_path_search_patterns(input_df,igraph,igraph_nodes,labels_all,edgelist,search_type,kg_type,manually_chosen_uris):
+def one_path_search_patterns(input_df,graph,search_type,kg_type,manually_chosen_uris):
     
     #print("Finding subgraph using user input and 1 shortest path......")
 
-    subgraph_df,manually_chosen_uris = subgraph_shortest_path_pattern(input_df,igraph,igraph_nodes,labels_all,edgelist,False,search_type,kg_type,manually_chosen_uris)
+    subgraph_df,manually_chosen_uris = subgraph_shortest_path_pattern(input_df,graph,False,search_type,kg_type,manually_chosen_uris)
 
     if len(subgraph_df) > 0:
         #Check pattern
-        pattern = process_dfs(kg_type,subgraph_df,labels_all)
+        pattern = process_dfs(kg_type,subgraph_df,graph.labels_all)
 
 
     return manually_chosen_uris,pattern

--- a/test_script.sh
+++ b/test_script.sh
@@ -22,4 +22,7 @@
 #python creating_subgraph_from_KG.py --input-dir ./Test_Data/Inputs_Covid19  --output-dir ./Test_Data/Inputs_Covid19 --knowledge-graph kg-covid19 --input-type annotated_diagram --guiding-term True
 
 #Command to test wikipathways_converter with pfocr urls file
-python wikipathways_converter.py --knowledge-graph pkl --input-type annotated_diagram --pfocr-urls-file True --enable-skipping True
+#python wikipathways_converter.py --knowledge-graph pkl --input-type annotated_diagram --pfocr-urls-file True --enable-skipping True
+
+#Command to test wikipathways pipeline by ID with smaller graph
+python call_all_pathways_wrapper.py --knowledge-graph pkl --input-type annotated_diagram --wikipathways "['WP4535']" --enable-skipping True


### PR DESCRIPTION
It was difficult to break this task up, so this is a large commit.

1. support for edge and node exclusion in graph object, edgelist, and labels dfs
2. always use networkx methods, though when igraph is specified by changing the method in create_graph, it will work
3. simplify functions to only pass graph class, rather than individually graph object, edgelist, and labels

To test, run ./test_script.sh. You can modify the WP4535_output/_annotated_diagram_Input_Nodes_.csv file to have fewer lines for a quicker test.